### PR TITLE
Make the examples adhere with the specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The editor supports 7 commands:
 In the example below, > denotes input, => denotes program output.
 
 ```
-> I56 
-> L23A 
+> I 5 6
+> L 2 3 A
 > S
 
 =>
@@ -40,9 +40,9 @@ OOOOO
 OOOOO
 OOOOO
 
-> F33J
-> V234W 
-> H342Z 
+> F 3 3 J
+> V 2 3 4 W
+> H 3 4 2 Z
 > S
 
 =>
@@ -56,4 +56,4 @@ JJJJJ
 
 ##￼Submission
 
-Fork this project, write some code, let us know! 
+Fork this project, write some code, let us know!


### PR DESCRIPTION
If I am not mistaken, there is a slight inconsistency in the specification.

It states:
"Arguments to the command are separated by spaces and follow the command character."

But the provided examples don't follow this format:

> I56 
> L23A 

This pull request makes the examples consistent with the specification.
